### PR TITLE
fix(build): resolve minor issues with toolchain script

### DIFF
--- a/toolchain/build-cross-tools.sh
+++ b/toolchain/build-cross-tools.sh
@@ -80,7 +80,7 @@ if [[ -d "$PREFIX" && -n $(ls -A "$PREFIX") ]]; then
   rm -rf "$LOCAL_DIR_PREFIX/$ARCH"
 fi
 
-disk_space_available=$(df -h "$DIR" | tail -n1 | awk '{ print $3 }')
+disk_space_available=$(df -h "$DIR" | tail -n1 | awk '{ print $4 }')
 echo "\
 This build step will download the source code for the GNU GCC $GCC_VERSION \
 compiler and the GNU Binutils $BINUTILS_VERSION binary tools. It will then \

--- a/toolchain/build-cross-tools.sh
+++ b/toolchain/build-cross-tools.sh
@@ -1,13 +1,26 @@
 #!/usr/bin/env bash
 
-# The majority of this script was taken from the Serenity OS project:
+# This script was heavily derived from the Serenity OS project:
 # https://github.com/SerenityOS/serenity/blob/311af9ad0590970e3e3c7384feed67c63aed08f4/Toolchain/BuildGNU.sh
 
 set -e
 set -o pipefail
 
-ARCH=${ARCH:-i686}
 OS_NAME="$(uname -s)"
+
+# Before doing anything, first check if we're on macOS with GNU coreutils
+# installed. If so, we'll modify PATH to prioritize GNU coreutils over native
+# utilities for platform consistency.
+if [ "$OS_NAME" = "Darwin" ]; then
+  if command -v brew > /dev/null; then
+    BREW_COREUTILS_PREFIX=$(brew --prefix coreutils 2>/dev/null)
+    if [ -n "$BREW_COREUTILS_PREFIX" ]; then
+      export PATH="$BREW_COREUTILS_PREFIX/libexec/gnubin:$PATH"
+    fi
+  fi
+fi
+
+ARCH=${ARCH:-i686}
 MAKE_JOBS=${MAKE_JOBS:-$(nproc)}
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/toolchain/build-cross-tools.sh
+++ b/toolchain/build-cross-tools.sh
@@ -87,8 +87,8 @@ compiler and the GNU Binutils $BINUTILS_VERSION binary tools. It will then \
 compile these tools, specified to target $ARCH-elf.
 
 This process will take a while to complete, depending on your machine's \
-specifications. Once complete, the resulting build artefacts will take up \
-around 3GB of disk space, give or take half a GB.
+specifications. Once complete, the resulting toolchain (downloaded tarballs, \
+source code, and build artifacts) will take up around 3GB of disk space. \
 
 You are on a(n) $OS_NAME system with $MAKE_JOBS processing unit(s) available \
 and $disk_space_available of disk space available.
@@ -217,3 +217,5 @@ pushd "$BUILD_DIR_PREFIX/$ARCH" > /dev/null
     log "$STEP_LIBGCC/install" make install-target-libgcc || exit 1
   popd > /dev/null # gcc
 popd > /dev/null # "$BUILD_DIR_PREFIX/$ARCH"
+
+echo "Toolchain built and installed successfully"

--- a/toolchain/build-cross-tools.sh
+++ b/toolchain/build-cross-tools.sh
@@ -165,6 +165,12 @@ pushd "$TARBALLS_DIR" > /dev/null
     log $STEP_DEPENDENCIES echo "Extracting GCC $GCC_VERSION..."
     tar -xJf "$GCC_TARBALL"
   fi
+
+  # Download gcc prerequisites
+  pushd $GCC_NAME > /dev/null
+    log $STEP_DEPENDENCIES echo "Downloading GCC $GCC_VERSION prerequisites..."
+    sh ./contrib/download_prerequisites
+  popd > /dev/null # "$GCC_TARBALL"
 popd > /dev/null # "$TARBALLS_DIR"
 
 # Build and install binutils and gcc


### PR DESCRIPTION
Fix #23 - incorrect available disk space statistic reported in prompt message.

Download GCC prerequisites before building toolchain. This will ensure toolchain will use prerequisites compatible with selected GCC version.

Ensure GNU coreutils binaries are available in `PATH` if host machine is `macOS` with Homebrew `coreutils` formula installed. Currently, the only GNU-only program used in the script is `nproc`.

Replace GNU-style `md5sum` checksum verification with POSIX-compliant manual comparison.

Clean up wording in printed messages.